### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-portablemc.ml


### PR DESCRIPTION
portablemc.ml is no longer up so just remove cname and let github host it from pages